### PR TITLE
Weapon skill keybind display & keybind display fixes

### DIFF
--- a/src/FileUtils.cpp
+++ b/src/FileUtils.cpp
@@ -546,13 +546,14 @@ std::map<std::string, KeybindInfo> parse_xml_keybinds(const std::filesystem::pat
 
                 keybind.action_name = get_keybind_action_name_from_xml_line(line);
 
-                auto button2_start = line.find("button2=\"");
-                bool has_button2 = button2_start != std::string::npos;
+                get_keybind_primary_info(line, keybind);
 
-                if (has_button2)
-                    get_keybind_secondary_info(button2_start, line, keybind);
-                else
-                    get_keybind_primary_info(line, keybind);
+                if (keybind.button == Keys::NONE)
+                {
+                    auto button2_start = line.find("button2=\"");
+                    if (button2_start != std::string::npos)
+                        get_keybind_secondary_info(button2_start, line, keybind);
+                }
 
                 if (!keybind.action_name.empty() && keybind.button != Keys::NONE)
                     keybinds[keybind.action_name] = keybind;

--- a/src/LogData.cpp
+++ b/src/LogData.cpp
@@ -1069,33 +1069,48 @@ std::string RotationLogType::get_keybind_str(const RotationStep &rotation_step,
                 log_skill_info_map.find(skill_key_mapping.skill_9) != log_skill_info_map.end()
             ? log_skill_info_map.find(skill_key_mapping.skill_9)->second.name
             : "";
-    const auto [keybind, modifier] = get_keybind_for_skill_type(skill_data.skill_slot, keybinds);
 
-    if (rotation_step.skill_data.name == skill_name_for_slot7)
+    auto skill_slot = skill_data.skill_slot;
+    const auto is_util_skill =
+        skill_slot == SkillSlot::UTILITY_1 || skill_slot == SkillSlot::UTILITY_2 || skill_slot == SkillSlot::UTILITY_3;
+    if (is_util_skill)
+    {
+        if (skill_key_mapping.skill_7 == skill_data.icon_id || skill_data.name == skill_name_for_slot7)
+            skill_slot = SkillSlot::UTILITY_1;
+        else if (skill_key_mapping.skill_8 == skill_data.icon_id || skill_data.name == skill_name_for_slot8)
+            skill_slot = SkillSlot::UTILITY_2;
+        else if (skill_key_mapping.skill_9 == skill_data.icon_id || skill_data.name == skill_name_for_slot9)
+            skill_slot = SkillSlot::UTILITY_3;
+    }
+
+    const auto [keybind, modifier] = get_keybind_for_skill_type(skill_slot, keybinds);
+
+    if (!Settings::XmlSettingsPath.empty() && keybind != Keys::NONE)
+    {
+        keybind_str = custom_keys_to_string(keybind);
+    }
+    else if (skill_slot == SkillSlot::UTILITY_1 &&
+             (skill_key_mapping.skill_7 == skill_data.icon_id || skill_data.name == skill_name_for_slot7))
     {
         keybind_str = "7";
     }
-    else if (rotation_step.skill_data.name == skill_name_for_slot8)
+    else if (skill_slot == SkillSlot::UTILITY_2 &&
+             (skill_key_mapping.skill_8 == skill_data.icon_id || skill_data.name == skill_name_for_slot8))
     {
         keybind_str = "8";
     }
-    else if (rotation_step.skill_data.name == skill_name_for_slot9)
+    else if (skill_slot == SkillSlot::UTILITY_3 &&
+             (skill_key_mapping.skill_9 == skill_data.icon_id || skill_data.name == skill_name_for_slot9))
     {
         keybind_str = "9";
     }
+    else if (keybind == Keys::NONE)
+    {
+        keybind_str = default_skillslot_to_string(skill_slot);
+    }
     else
     {
-        if (Settings::XmlSettingsPath.empty())
-        {
-            keybind_str = default_skillslot_to_string(skill_data.skill_slot);
-        }
-        else
-        {
-            if (keybind == Keys::NONE)
-                keybind_str = default_skillslot_to_string(skill_data.skill_slot);
-            else
-                keybind_str = custom_keys_to_string(keybind);
-        }
+        keybind_str = custom_keys_to_string(keybind);
     }
 
     if (modifier != Modifiers::NONE)

--- a/src/RotationRender.cpp
+++ b/src/RotationRender.cpp
@@ -78,6 +78,38 @@ SkillSlot GetSkillSlotFromSettings(const SkillID skill_id)
     return SkillSlot::NONE;
 }
 
+SkillSlot GetUtilitySkillSlotFromKeyMapping(const int icon_id)
+{
+    const auto &skill_key_mapping = Globals::RotationRun.skill_key_mapping;
+
+    if (skill_key_mapping.skill_7 == icon_id)
+        return SkillSlot::UTILITY_1;
+    if (skill_key_mapping.skill_8 == icon_id)
+        return SkillSlot::UTILITY_2;
+    if (skill_key_mapping.skill_9 == icon_id)
+        return SkillSlot::UTILITY_3;
+
+    return SkillSlot::NONE;
+}
+
+SkillSlot ResolveUtilitySkillSlot(const SkillID skill_id, const int icon_id, SkillSlot skill_slot)
+{
+    const auto is_util_skill =
+        skill_slot == SkillSlot::UTILITY_1 || skill_slot == SkillSlot::UTILITY_2 || skill_slot == SkillSlot::UTILITY_3;
+    if (!is_util_skill)
+        return skill_slot;
+
+    const auto from_settings = GetSkillSlotFromSettings(skill_id);
+    if (from_settings != SkillSlot::NONE)
+        return from_settings;
+
+    const auto from_key_mapping = GetUtilitySkillSlotFromKeyMapping(icon_id);
+    if (from_key_mapping != SkillSlot::NONE)
+        return from_key_mapping;
+
+    return skill_slot;
+}
+
 std::string DefaultKeybinds(const int icon_id, const SkillSlot skill_slot)
 {
     const auto &skill_key_mapping = Globals::RotationRun.skill_key_mapping;
@@ -94,28 +126,13 @@ std::string DefaultKeybinds(const int icon_id, const SkillSlot skill_slot)
 
 std::string KeybindWithoutXML(const SkillID skill_id, const int icon_id, SkillSlot skill_slot)
 {
-    const auto &skill_key_mapping = Globals::RotationRun.skill_key_mapping;
-    const auto is_util_skill =
-        skill_slot == SkillSlot::UTILITY_1 || skill_slot == SkillSlot::UTILITY_2 || skill_slot == SkillSlot::UTILITY_3;
-
-    if (is_util_skill)
-        skill_slot = GetSkillSlotFromSettings(skill_id);
-
+    skill_slot = ResolveUtilitySkillSlot(skill_id, icon_id, skill_slot);
     return DefaultKeybinds(icon_id, skill_slot);
 }
 
 std::string KeybindFromMappingAndXML(const SkillID skill_id, const int icon_id, SkillSlot skill_slot)
 {
-    const auto &skill_key_mapping = Globals::RotationRun.skill_key_mapping;
-    const auto is_util_skill =
-        skill_slot == SkillSlot::UTILITY_1 || skill_slot == SkillSlot::UTILITY_2 || skill_slot == SkillSlot::UTILITY_3;
-
-    if (is_util_skill)
-    {
-        auto _skill_slot = GetSkillSlotFromSettings(skill_id);
-        if (_skill_slot != SkillSlot::NONE)
-            skill_slot = _skill_slot;
-    }
+    skill_slot = ResolveUtilitySkillSlot(skill_id, icon_id, skill_slot);
 
     const auto &[keybind, modifier] = get_keybind_for_skill_type(skill_slot, Globals::RenderData.keybinds);
     if (keybind == Keys::NONE)
@@ -132,11 +149,11 @@ std::string KeybindFromMappingAndXML(const SkillID skill_id, const int icon_id, 
 
 std::string KeybindWithXML(const SkillID skill_id, const int icon_id, SkillSlot skill_slot)
 {
-    const auto &skill_key_mapping = Globals::RotationRun.skill_key_mapping;
     const auto is_util_skill =
         skill_slot == SkillSlot::UTILITY_1 || skill_slot == SkillSlot::UTILITY_2 || skill_slot == SkillSlot::UTILITY_3;
     auto keybind_str = std::string{};
 
+    skill_slot = ResolveUtilitySkillSlot(skill_id, icon_id, skill_slot);
     const auto &[keybind, modifier] = get_keybind_for_skill_type(skill_slot, Globals::RenderData.keybinds);
 
     if (is_util_skill || keybind == Keys::NONE)

--- a/src/TypesUtils.cpp
+++ b/src/TypesUtils.cpp
@@ -652,6 +652,21 @@ std::pair<Keys, Modifiers> get_keybind_for_skill_type(SkillSlot skill_slot,
 
     switch (skill_slot)
     {
+    case SkillSlot::WEAPON_1:
+        action_name = "Weapon Skill 1";
+        break;
+    case SkillSlot::WEAPON_2:
+        action_name = "Weapon Skill 2";
+        break;
+    case SkillSlot::WEAPON_3:
+        action_name = "Weapon Skill 3";
+        break;
+    case SkillSlot::WEAPON_4:
+        action_name = "Weapon Skill 4";
+        break;
+    case SkillSlot::WEAPON_5:
+        action_name = "Weapon Skill 5";
+        break;
     case SkillSlot::PROFESSION_1:
         action_name = "Profession Skill 1";
         break;

--- a/src/TypesUtils.cpp
+++ b/src/TypesUtils.cpp
@@ -6,6 +6,8 @@
 #include <utility>
 #include <vector>
 
+#include <windows.h>
+
 #include "FileUtils.h"
 #include "Shared.h"
 #include "SkillData.h"
@@ -502,7 +504,9 @@ std::string custom_keys_to_string(Keys key)
     case Keys::EQUAL:
         return "=";
     case Keys::ZIRUMFLEX:
-        return "^";
+        if (PRIMARYLANGID(LOWORD(GetKeyboardLayout(0))) == LANG_GERMAN)
+            return "^";
+        return "`";
     case Keys::TAB:
         return "Tab";
     case Keys::F1:

--- a/src/entry.cpp
+++ b/src/entry.cpp
@@ -100,7 +100,7 @@ extern "C" __declspec(dllexport) AddonDefinition_t *GetAddonDef()
     AddonDef.Version.Revision = REVISION;
     AddonDef.Author = "Franneck.1274";
     AddonDef.Description = "Displays the player's skill rotation and helps "
-                           "improving it by providing visual feedback.";
+                           "improve it by providing visual feedback.";
     AddonDef.Load = AddonLoad;
     AddonDef.Unload = AddonUnload;
     AddonDef.Flags = AF_None;


### PR DESCRIPTION
Added code to get the weapon skill keybinds (Weapon Skill 1 through Weapon Skill 5) 

Changed the primary vs secondary keybind display logic, so if a skill does have a primary keybind it will display that over the secondary one

Keybind displays ` or ^ based on keyboard layout (noticed it defaulted to german version, this should work properly with that layout, but cannot test myself.

Also a minor grammatical fix in description